### PR TITLE
Register extension after Tree Style Tab restart

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -49,9 +49,10 @@
       });
       add();
 
-      chrome.runtime.onMessageExternal.addListener((request, sender) => {
+      chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
         if (sender.id === TST && request.type === 'ready') {
           add();
+          sendResponse(true);
         }
       });
     };


### PR DESCRIPTION
Tree Style Tab caches extension that register to it in its local storage. If they don't respond with true to the "ready" message then they will be removed from this cache. If Tree Style Tab is restarted (updated, disabled/enabled or the browser is restarted) and this extension isn't in its cache then it will not be sent a "ready" message and will not be re-registered to Tree Style Tab.

## Steps to reproduce issue
 1. Install Tree Style Tab.
 2. Install Auto Tab Discard.
 3. Disable and then enable Tree Style Tab.
 4. Observe that Auto Tab Discard was cached. Tree Style Tab should send a "ready" message and Auto Tab Discard should re-register.
 5. Disable and then enabled Tree Style Tab again.
 6. Observe that Auto Tab Discard wasn't cached. Tree Style Tab didn't send a "ready" message and Auto Tab Discard's doesn't register to Tree Style Tab.

