### PR TITLE
Compatibility with other tab unloaders

### DIFF
--- a/data/inject/top.js
+++ b/data/inject/top.js
@@ -165,7 +165,7 @@ var check = async(period, manual = false, bypass = false) => {
   }
 };
 
-document.addEventListener('visibilitychange', () => check());
+document.addEventListener('visibilitychange', () => setTimeout(check, 0));
 // https://github.com/rNeomy/auto-tab-discard/issues/1
 document.addEventListener('DOMContentLoaded', () => check());
 


### PR DESCRIPTION
When other tab unloaders want to unload the active tab they will switch away from it and then discard it. When the active tab is changed this triggers the listener to the `visibilitychange` event in the file [auto-tab-discard/data/inject/top.js at line 168](https://github.com/rNeomy/auto-tab-discard/blob/master/data/inject/top.js#L168). This listener will send a message to the background script and this message causes Firefox to set the `discarded` property to false.

This pull request fixes this issue by adding a slight delay to the message so that if the tab is being unloaded then the message won't be sent.

## Steps to reproduce issue
 1. Install [Auto Tab Discard](https://addons.mozilla.org/firefox/addon/auto-tab-discard/).
 2. Install [Unload Tab](https://addons.mozilla.org/firefox/addon/unload-tab/).
 3. Install an extension that shows if a tab is unloaded. For example [Tab Center Redux](https://addons.mozilla.org/firefox/addon/tab-center-redux/).
 4. Switch to a tab that supports context script. (For example google.)
 5. Unload the active tab with the Unload Tab extension. (Use `alt+x` shortcut.)
 6. Observe how the discarded tab look loaded even though it isn't.

Browser: Firefox v60.0.1