### PR TITLE
Hidden tab efficiency

### DIFF
--- a/hidden.js
+++ b/hidden.js
@@ -16,9 +16,7 @@
   hidden.observe = (id, info, tab) => {
     if ('hidden' in info && tab.url.startsWith('http')) {
       if (tab.hidden && tab.discarded === false) {
-        chrome.storage.local.get({
-          'go-hidden': false
-        }, prefs => prefs['go-hidden'] && discard(tab));
+        discard(tab);
       }
     }
   };

--- a/hidden.js
+++ b/hidden.js
@@ -21,12 +21,8 @@
     }
   };
 
-  chrome.storage.onChanged.addListener(prefs => prefs['go-hidden'] && hidden.install());
   if (isFirefox) {
+    chrome.storage.onChanged.addListener(prefs => prefs['go-hidden'] && hidden.install());
     hidden.install();
-  }
-  else {
-    chrome.runtime.onInstalled.addListener(hidden.install);
-    chrome.runtime.onStartup.addListener(hidden.install);
   }
 }

--- a/hidden.js
+++ b/hidden.js
@@ -9,7 +9,7 @@
   }, prefs => {
     chrome.tabs.onUpdated.removeListener(hidden.observe);
     if (prefs['go-hidden']) {
-      chrome.tabs.onUpdated.addListener(hidden.observe);
+      chrome.tabs.onUpdated.addListener(hidden.observe, { properties: ["hidden"] });
     }
   });
 


### PR DESCRIPTION
This pull request should reduce CPU usage for tracking hidden tabs
- Do not track hidden tabs on Browsers besides Firefox (AFAIK this feature is inly supported by Firefox)
- On Firefox use the filter concept described here https://developer.mozilla.org/de/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated#Parameters to only listen for changes of tabs hidden property
- Do not check pref for every tabs hidden attribute change since the chrome.storage.onChanged listener should handle this