### PR TITLE
Support TST 3.0.12 and later

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -103,6 +103,9 @@
   starters.push(onStartup);
 
   const onClicked = async (info, tab) => {
+    if (tab && !tab.url) { // Tree Style Tab 3.0.12 and later don't deliver a real tab.
+      tab = await browser.tabs.get(tab.id);
+    }
     const {menuItemId} = info;
     if (menuItemId === 'whitelist-domain') {
       const {hostname, protocol = ''} = new URL(tab.url);


### PR DESCRIPTION
On TST 3.0.12 and later, `tab` and `tabs` delivered via its API won't have `tabs.Tab` compatible properties by default, due to security reasons. I think that these changes should make this addon compatible to TST 3.0.12 and later.

For more details, please see the updated API document:
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#extra-permissions
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#data-format