### PR TITLE
Check if Notifications API available

### DIFF
--- a/data/inject/top.js
+++ b/data/inject/top.js
@@ -117,7 +117,8 @@ tools.permission = () => {
   if (prefs['notification.permission'] === false) {
     return Promise.resolve(false);
   }
-  return new Promise(resolve => resolve(Notification.permission === 'granted'));
+  return new Promise(resolve => resolve(Notification &&
+                                        Notification.permission === 'granted'));
 };
 tools.urlBased = () => {
   if (prefs.mode === 'url-based') {


### PR DESCRIPTION
Notification API can be disabled in Firefox via the `dom.webnotifications.enabled` flag (e.g. to avoid spammy requests from every other website).

If `prefs['notification.permission']` remained enabled, the addon was failing with:

    ReferenceError: Notification is not defined