### PR TITLE
add trash startup process and delay. add utility helper.

### DIFF
--- a/plugins/trash/core.js
+++ b/plugins/trash/core.js
@@ -1,60 +1,131 @@
 /* global log, storage, query */
 
+/* define utility helper functions */
+const Utils = {
+  time: {
+    check: (key, value, timeoutHours) => {
+      const age = Date.now() - value;
+      const timeout = Utils.time.converters.hoursToMilliseconds(timeoutHours);
+      const millisecondsRemaining = timeout - age;
+      const minutesRemaining = Utils.time.converters.millisecondsToMinutes(
+        millisecondsRemaining
+      );
+      return [minutesRemaining, `minutes remaining for ${key}`];
+    },
+    logRemaining: (urlMap, timeoutHours) => {
+      let list = [];
+      for (const [key, value] of Object.entries(urlMap)) {
+        list.push(Utils.time.check(key, value, timeoutHours));
+      }
+      list.sort((a, b) => a[0] - b[0]);
+      list = list.map((item) => item.join(' '));
+      log('logRemaining:time remaining for keys', list);
+    },
+    converters: {
+      hoursToMilliseconds: (hours) => hours * 60 * 60 * 1000,
+      millisecondsToMinutes: (milliseconds) =>
+        (milliseconds / 1000 / 60).toFixed(),
+    },
+  },
+};
+
+/*
+  collect and discard tabs at startup so that storage syncs with tabs.
+  because on startup tabs do not retain their discarded state.
+*/
+const trashStartup = {
+  discard: async (tabs = []) => {
+    return await new Promise(async (resolve) => {
+      const tabDiscardPromises = [];
+      for (const tab of tabs) {
+        log('trashStartup:discarding tab', tab.url, tab);
+        tabDiscardPromises.push(discard(tab));
+      }
+      await Promise.all(tabDiscardPromises);
+      log('trashStartup:tab discards complete');
+      resolve();
+    });
+  },
+  isComplete: false,
+  run: async () => {
+    await query({
+      discarded: false,
+      active: false,
+    }).then(async (tabs = []) => {
+      log('trashStartup:tabs', tabs);
+      await trashStartup.discard(tabs);
+      trashStartup.isComplete = true;
+      log('trashStartup:complete');
+    });
+  },
+};
+
 function enable() {
-  log('trash.install is called');
+  log('trash.enable is called');
   storage({
-    'trash.interval': 30 // in minutes
-  }).then(prefs => chrome.alarms.create('trash.check', {
-    when: Date.now(),
-    periodInMinutes: prefs['trash.interval']
-  }));
+    'trash.interval': 30, // in minutes
+  }).then((prefs) =>
+    chrome.alarms.create('trash.check', {
+      when: Date.now() + 10000,
+      periodInMinutes: prefs['trash.interval'],
+    })
+  );
 }
 function disable() {
   chrome.alarms.clear('trash.check');
   chrome.storage.local.remove('trash.keys');
 }
 
-chrome.alarms.onAlarm.addListener(alarm => {
+chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === 'trash.check') {
-    log('alarm fire', 'trash.check', alarm.name);
+    log('alarm fire', alarm.name);
+    if (!trashStartup.isComplete) {
+      await trashStartup.run();
+    }
     query({
-      discarded: true
+      discarded: true,
     }).then((tbs = []) => {
-      const keys = tbs.map(t => t.url);
+      const keys = tbs.map((t) => t.url);
       const now = Date.now();
       const removed = [];
       storage({
         'trash.period': 24, // in hours
-        'trash.keys': {}
-      }).then(prefs => {
-        for (const [key, value] of Object.entries(prefs['trash.keys'])) {
+        'trash.keys': {},
+      }).then((prefs) => {
+        const timeoutPeriod = prefs['trash.period'];
+        const urlMap = prefs['trash.keys'];
+
+        for (const [key, value] of Object.entries(urlMap)) {
           // remove removed keys
           if (keys.indexOf(key) === -1) {
-            delete prefs['trash.keys'][key];
+            delete urlMap[key];
           }
           // remove old tabs
-          else if (now - value > prefs['trash.period'] * 60 * 60 * 1000) {
-            delete prefs['trash.keys'][key];
+          else if (
+            now - value >
+            Utils.time.converters.hoursToMilliseconds(timeoutPeriod)
+          ) {
+            delete urlMap[key];
             removed.push(key);
-            for (const tb of tbs.filter(t => t.url === key)) {
-              log('trash', 'removing', tb.title);
+            for (const tb of tbs.filter((t) => t.url === key)) {
+              log('trash removing', tb.title, tb.url);
               chrome.tabs.remove(tb.id, () => chrome.runtime.lastError);
             }
           }
         }
         // add new keys
         for (const key of keys) {
-          if (prefs['trash.keys'][key] === undefined && removed.indexOf(key) === -1) {
-            prefs['trash.keys'][key] = now;
+          if (urlMap[key] === undefined && removed.indexOf(key) === -1) {
+            urlMap[key] = now;
           }
         }
+
+        log('alarm:trash.check:saving prefs', prefs);
         chrome.storage.local.set(prefs);
+        Utils.time.logRemaining(urlMap, timeoutPeriod);
       });
     });
   }
 });
 
-export {
-  enable,
-  disable
-};
+export { enable, disable };


### PR DESCRIPTION
hello @rNeomy 

first, thank you for your work on this helpful and well-designed application!

while investigating #243, i found that some tabs do not retain their discarded state between restarts of the browser, and this was causing those tabs to never be removed by the trash process.

because the trash alarm is only querying for discarded tabs, some tabs were not being collected, and then were being assigned a new trash timeout--which means that they would not be removed as expected.

this pull-request fixes #243 by adding a trash startup process that discards inactive, undiscarded tabs before the trash alarm process runs.

i tested this on Brave and Firefox and all seems to be working.

i apologize for the formatting changes, the formatting setup on my machine 'cleaned things up'. 😁 

please review the changes and let me know what you think.
thank you,
daniel
