### PR TITLE
Support custom intervals for trash whitelist rules as discussed in #260

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -170,6 +170,9 @@
   "options_footnote_3": {
     "message": "When the discarding period is over for a tab or a new tab is added, all browser's tabs are checked to evaluate which tabs need to be discarded. This option forces the extension to limit these checks. The minimum acceptable value is 1 minute. The recommended value is 10 minutes."
   },
+  "options_footnote_4": {
+    "message": "To use a custom time interval for a rule, add @{number}{unit} to the end. e.g. a rule of google.com@3d will trash google.com URLs after 3 days.  Valud units are (s)econds, (m)inutes, (h)ours, (d)ays, (w)weeks, and (mo)nths"
+  },
   "options_reset": {
     "message": "Factory Reset"
   },

--- a/data/options/index.html
+++ b/data/options/index.html
@@ -226,7 +226,7 @@
         <tr>
             <td></td>
             <td colspan="2">
-                <span style="display: block; padding-bottom: 10px;"><span data-i18n="options_plugin_trash_whitelist"></span><sup>1</sup></span>
+                <span style="display: block; padding-bottom: 10px;"><span data-i18n="options_plugin_trash_whitelist"></span><sup>1, 4</sup></span>
                 <textarea rows="3" id="trash.whitelist-url" placeholder="Comma-separated list of hostnames, leave blank for all"></textarea>
             </td>
         </tr>
@@ -291,6 +291,7 @@
       <li><span data-i18n="options_footnote_1"></span></li>
       <li><span data-i18n="options_footnote_2"></span></li>
       <li><span data-i18n="options_footnote_3"></span></li>
+      <li><span data-i18n="options_footnote_4"></span></li>
     </ol>
 
     <script src="index.js"></script>


### PR DESCRIPTION
Allows trashing of discarded tabs to be done using a custom time interval, e.g.:
`re:google.com@3d` to trash Google URLs after 3 days.