### PR TITLE
Fix typo

### DIFF
--- a/v3/_locales/it/messages.json
+++ b/v3/_locales/it/messages.json
@@ -264,7 +264,7 @@
         "description": ""
     },
     "popup_discard_tab": {
-        "message": "Sospenti la scheda",
+        "message": "Sospendi la scheda",
         "description": ""
     },
     "popup_discard_tree": {


### PR DESCRIPTION
Sospenti --> Sospendi
Same typo still present in manifest v2 version (take a look here: https://github.com/rNeomy/auto-tab-discard/pull/280)