### PR TITLE
Added Plugin for Odysee Timestamps and compatibility with Firefox

### DIFF
--- a/misc/description.txt
+++ b/misc/description.txt
@@ -32,6 +32,7 @@ The available plugins for "Auto Tab Discard" are:
   * Release the discarded state of all tabs in the active window.
   * Automatically discard all newly opened inactive tabs.
   * Store YouTube's timestamp before a tab is discarded.
+  * Store Odysee's timestamp before a tab is discarded.
   * Permanently delete (remove) old discarded tabs that are inactive.
 
 Notes:

--- a/v3/_locales/de/messages.json
+++ b/v3/_locales/de/messages.json
@@ -199,6 +199,10 @@
         "message": "Speichere YouTube's Zeitmarke vor dem deaktivieren",
         "description": ""
     },
+    "options_plugin_odysee": {
+        "message": "Speichere Odysee's Zeitmarke vor dem deaktivieren",
+        "description": ""
+    },
     "options_log": {
         "message": "Protokolle anzeigen (Verwendung zur Fehlersuche)",
         "description": ""

--- a/v3/_locales/en/messages.json
+++ b/v3/_locales/en/messages.json
@@ -164,6 +164,9 @@
   "options_plugin_youtube": {
     "message": "Store YouTube's timestamp before discarding"
   },
+  "options_plugin_odysee" : {
+    "message": "Store Odysee's timestamp before discarding"
+  },
   "options_log": {
     "message": "Display logs (for debugging purpose only)"
   },

--- a/v3/data/options/index.html
+++ b/v3/data/options/index.html
@@ -225,6 +225,10 @@
           <td colspan="2"><label for="./plugins/youtube/core.js" data-i18n="options_plugin_youtube"></label></td>
         </tr>
         <tr>
+          <td><input type="checkbox" id="./plugins/odysee/core.js"></td>
+            <td colspan="2"><label for="./plugins/odysee/core.js" data-i18n="options_plugin_odysee"></label></td>
+        </tr>
+        <tr>
           <td><input type="checkbox" id="./plugins/trash/core.js"></td>
           <td colspan="2">
               <label for="./plugins/trash/core.js" data-i18n="options_plugin_trash01"></label>

--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -76,7 +76,8 @@ const restore = () => storage({
   './plugins/previous/core.js': false,
   './plugins/new/core.js': false,
   './plugins/unloaded/core.js': false,
-  './plugins/youtube/core.js': false
+  './plugins/youtube/core.js': false,
+  './plugins/odysee/core.js': false
 }).then(prefs => {
   if (navigator.getBattery === undefined) {
     document.getElementById('battery_enabled').closest('tr').disabled = true;
@@ -133,6 +134,7 @@ const restore = () => storage({
   document.getElementById('./plugins/new/core.js').checked = prefs['./plugins/new/core.js'];
   document.getElementById('./plugins/unloaded/core.js').checked = prefs['./plugins/unloaded/core.js'];
   document.getElementById('./plugins/youtube/core.js').checked = prefs['./plugins/youtube/core.js'];
+  document.getElementById('./plugins/odysee/core.js').checked = prefs['./plugins/odysee/core.js'];
 });
 
 document.getElementById('save').addEventListener('click', () => {
@@ -217,7 +219,8 @@ document.getElementById('save').addEventListener('click', () => {
     './plugins/previous/core.js': document.getElementById('./plugins/previous/core.js').checked,
     './plugins/new/core.js': document.getElementById('./plugins/new/core.js').checked,
     './plugins/unloaded/core.js': document.getElementById('./plugins/unloaded/core.js').checked,
-    './plugins/youtube/core.js': document.getElementById('./plugins/youtube/core.js').checked
+    './plugins/youtube/core.js': document.getElementById('./plugins/youtube/core.js').checked,
+    './plugins/odysee/core.js': document.getElementById('./plugins/odysee/core.js').checked
   }, () => {
     info.textContent = chrome.i18n.getMessage('options_save_msg');
     restore();

--- a/v3/manifest.json
+++ b/v3/manifest.json
@@ -28,6 +28,7 @@
     "*://*/*"
   ],
   "background": {
+    "scripts": ["worker/core.mjs"],
     "service_worker": "worker/core.mjs",
     "type": "module"
   },
@@ -84,5 +85,10 @@
   "web_accessible_resources": [{
     "resources": ["/data/page.png"],
     "matches": ["*://*/*"]
-  }]
+  }],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{c2c003ee-bd69-42a2-b0e9-6f34222cb046}"
+    }
+  }
 }

--- a/v3/worker/modes/number.mjs
+++ b/v3/worker/modes/number.mjs
@@ -375,7 +375,7 @@ starters.push(() => chrome.app && query({
   url: '*://*/*',
   discarded: false
 }).then(tbs => {
-  const contentScripts = chrome.app.getDetails().content_scripts;
+  const contentScripts = chrome.runtime.getManifest().content_scripts;
   for (const tab of tbs) {
     for (const cs of contentScripts) {
       chrome.scripting.executeScript({

--- a/v3/worker/plugins/loader.mjs
+++ b/v3/worker/plugins/loader.mjs
@@ -9,6 +9,7 @@ import blank from './blank/core.mjs';
 import create from './create/core.mjs';
 import unloaded from './unloaded/core.mjs';
 import youtube from './youtube/core.mjs';
+import odysee from './odysee/core.mjs';
 
 const D = {
   'before-menu-click'() {
@@ -39,7 +40,8 @@ const ready = storage({
   './plugins/blank/core.js': true,
   './plugins/new/core.js': false,
   './plugins/unloaded/core.js': false,
-  './plugins/youtube/core.js': false
+  './plugins/youtube/core.js': false,
+  './plugins/odysee/core.js': false
 }).then(prefs => {
   startup.enable();
 
@@ -69,6 +71,9 @@ const ready = storage({
   }
   if (prefs['./plugins/youtube/core.js']) {
     youtube.enable();
+  }
+  if (prefs['./plugins/odysee/core.js']) {
+    odysee.enable();
   }
 });
 
@@ -100,6 +105,9 @@ chrome.storage.onChanged.addListener(ps => {
   }
   if ('./plugins/youtube/core.js' in ps) {
     youtube[ps['./plugins/youtube/core.js'].newValue ? 'enable' : 'disable']();
+  }
+  if ('./plugins/odysee/core.js' in ps) {
+    odysee[ps['./plugins/odysee/core.js'].newValue ? 'enable' : 'disable']();
   }
 });
 

--- a/v3/worker/plugins/odysee/core.mjs
+++ b/v3/worker/plugins/odysee/core.mjs
@@ -1,0 +1,46 @@
+import {log} from '../../core/utils.mjs';
+import {discard} from '../../core/discard.mjs';
+
+const perform = discard.perform;
+
+function enable() {
+  log('installing odysee/core.js');
+  discard.perform = tab => {
+    if (tab.url && tab.url.startsWith('https://odysee.com/')) {
+      chrome.scripting.executeScript({
+        target: {
+          tabId: tab.id
+        },
+        world: 'MAIN',
+        func: () => {
+          /**
+           * @type {HTMLVideoElement}
+           */
+          const player = document.querySelector('#vjs_video_3_html5_api');
+          if (player) {
+            const t = player.currentTime;
+            if (t) {
+              const s = new URLSearchParams(location.search);
+              s.set('t', t.toString());
+              history.replaceState(history.state, '', '?' + s.toString());
+            }
+          }
+        }
+      }).catch(e => {
+        console.error('plugins/odysee -> error', e);
+      }).then(() => perform(tab));
+    }
+    else {
+      perform(tab);
+    }
+  };
+}
+function disable() {
+  log('removing odysee/core.js');
+  discard.perform = perform;
+}
+
+export default {
+  enable,
+  disable
+};


### PR DESCRIPTION
For Issue #390 I added the new Odysee timestamp plugin with the options button translations for english and german.

While working on that new plugin, I noticed that the Extension hasn't gotten a updated on Firefox since version 0.6.7 and noticed that the current version isn't compatible with Firefox anymore. ([background.service_worker](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support) is not supported (see [Firefox bug 1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659)).
So I fixed the manifest.json for Firefox compatibility and stated using chrome.runtime.getManifest() instead of chrome.app.getDetails() because app.getDetails() is deprecated by Firefox and [runtime.getManifest()](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getManifest) also allows accessing content_scripts from the manifest and is not deprecated.
So Issue #371 should also be addressed if it will get uploaded to the Firefox extension store