### PR TITLE
Apply the theme to input fields and text areas

### DIFF
--- a/v2/data/options/index.css
+++ b/v2/data/options/index.css
@@ -21,6 +21,11 @@ body {
   max-width: 80%;
   margin: auto;
 }
+textarea,
+input {
+  background-color: var(--dark);
+  color: var(--clr);
+}
 @media screen and (max-width: 600px) {
   body {
     margin: 10px;

--- a/v3/data/options/index.css
+++ b/v3/data/options/index.css
@@ -36,6 +36,11 @@ input {
   border: solid 1px rgba(0, 0, 0, 0.25);
   outline: none;
 }
+textarea,
+input {
+  background-color: var(--dark);
+  color: var(--clr);
+}
 button:focus,
 textarea:focus,
 input:focus {


### PR DESCRIPTION
Tested the `v2` version in Firefox:

Dark:

<img width="468" alt="圖片" src="https://github.com/user-attachments/assets/96b0b4a0-a2d3-45af-b015-58262911327c">

Light:

<img width="347" alt="圖片" src="https://github.com/user-attachments/assets/890f097a-74fb-44bc-bdd1-4345ee992710">

I didn’t test `v3` because Firefox doesn’t seem to support it.