### PR TITLE
fix: remove managed_schema from manifest to eliminate Firefox warning

### DIFF
--- a/v2/manifest.json
+++ b/v2/manifest.json
@@ -17,9 +17,7 @@
     "128": "data/icons/128.png",
     "256": "data/icons/256.png"
   },
-  "storage": {
-    "managed_schema": "schema.json"
-  },
+  "storage": {},
   "permissions": [
     "idle",
     "storage",

--- a/v3/manifest.json
+++ b/v3/manifest.json
@@ -13,9 +13,7 @@
     "256": "/data/icons/256.png",
     "512": "/data/icons/512.png"
   },
-  "storage": {
-    "managed_schema": "schema.json"
-  },
+  "storage": {},
   "permissions": [
     "idle",
     "storage",


### PR DESCRIPTION
Firefox reports: 'Warning processing storage: An unexpected property was found in the WebExtension manifest' because managed_schema is not fully supported by Firefox.

The managed_schema property is only used by Chrome to provide documentation for IT administrators about available managed storage options. The extension code does not depend on this property — it uses chrome.storage.managed API directly, which works without the schema.

Removing managed_schema eliminates the warning while keeping full functionality for both local and managed storage configurations.