### PR TITLE
fix: Update Chrome Web Store URLs to new chromewebstore format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A browser extension which uses the native tab discarding method (`chrome.tabs.di
 
   * Homepage: https://webextension.org/listing/tab-discard.html
   * Privacy Policy: https://webextension.org/privacy-policy/extension/tab-discard.html
-  * Chrome: https://chrome.google.com/webstore/detail/auto-tab-discard/jhnleheckmknfcgijgkadoemagpecfol
+  * Chrome: https://chromewebstore.google.com/detail/auto-tab-discard/jhnleheckmknfcgijgkadoemagpecfol
   * Edge: https://microsoftedge.microsoft.com/addons/detail/auto-tab-discard/nfkkljlcjnkngcmdpcammanncbhkndfe
   * Firefox: https://addons.mozilla.org/firefox/addon/auto-tab-discard/
   * Opera: https://addons.opera.com/en/extensions/details/auto-tab-discard/

--- a/v2/data/options/index.html
+++ b/v2/data/options/index.html
@@ -266,7 +266,7 @@
       </tbody>
     </table>
     <div id="explore" data-cols="5"></div>
-    <p>Rate "<a id="rate" target="_blank" href="https://chrome.google.com/webstore/detail/auto-tab-discard/jhnleheckmknfcgijgkadoemagpecfol/reviews">Auto Tab Discard</a>" extension</p>
+    <p>Rate "<a id="rate" target="_blank" href="https://chromewebstore.google.com/detail/auto-tab-discard/jhnleheckmknfcgijgkadoemagpecfol/reviews">Auto Tab Discard</a>" extension</p>
     <p>
       <div class="admin">This extension supports managed storage. All the preferences can be pre-configured by <a href="https://add0n.com/tab-discard.html#faq10">the domain administrator</a></div>
       <table width=100%>

--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -263,7 +263,7 @@ document.getElementById('reset').addEventListener('click', e => {
 });
 // rate
 document.querySelector('#rate input').onclick = () => {
-  let url = 'https://chrome.google.com/webstore/detail/auto-tab-discard/jhnleheckmknfcgijgkadoemagpecfol/reviews';
+  let url = 'https://chromewebstore.google.com/detail/auto-tab-discard/jhnleheckmknfcgijgkadoemagpecfol/reviews';
   if (isFirefox) {
     url = 'https://addons.mozilla.org/firefox/addon/auto-tab-discard/reviews/';
   }


### PR DESCRIPTION
## Summary
Updates deprecated Chrome Web Store URLs (chrome.google.com/webstore) to the new format (chromewebstore.google.com).

## Changes
- `README.md`: Updated extension store link
- `v2/data/options/index.html`: Updated review link
- `v3/data/options/index.js`: Updated review link

This fix follows Google's URL migration for the Chrome Web Store.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*