### PR TITLE
Clarify terminology for when temporary disable is not in use (from "Off" to "Never") [all translations included]

### DIFF
--- a/v3/_locales/el/messages.json
+++ b/v3/_locales/el/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Ανενεργό",
+        "message": "Ποτέ",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/en/messages.json
+++ b/v3/_locales/en/messages.json
@@ -282,7 +282,7 @@
     "message": "Disable Auto Discarding Globally for"
   },
   "popup_tmp_0": {
-    "message": "Off"
+    "message": "Never"
   },
   "popup_tmp_1": {
     "message": "1 hour"

--- a/v3/_locales/es/messages.json
+++ b/v3/_locales/es/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Off",
+        "message": "Nunca",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/hu/messages.json
+++ b/v3/_locales/hu/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Ki",
+        "message": "Soha",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/ja/messages.json
+++ b/v3/_locales/ja/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "オフ",
+        "message": "決して",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/nl/messages.json
+++ b/v3/_locales/nl/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Uit",
+        "message": "Nooit",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/pt/messages.json
+++ b/v3/_locales/pt/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Desligado",
+        "message": "Nunca",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/ru/messages.json
+++ b/v3/_locales/ru/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Отключено",
+        "message": "Никогда",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/sv/messages.json
+++ b/v3/_locales/sv/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "Av",
+        "message": "Aldrig",
         "description": ""
     },
     "popup_tmp_1": {

--- a/v3/_locales/zh_CN/messages.json
+++ b/v3/_locales/zh_CN/messages.json
@@ -376,7 +376,7 @@
         "description": ""
     },
     "popup_tmp_0": {
-        "message": "不禁用",
+        "message": "绝不",
         "description": ""
     },
     "popup_tmp_1": {


### PR DESCRIPTION
#### Overview of this pull request:
Change the dialog option *"Disable Auto Tab Discarding Globally"*'s *"Off"* text to *"Never"*, for clarity.  
(It is the menu option that allows temporarily disabling this extension for a certain amount of time.)  

#### Reasoning:
The meaning for *"Off"* in this context is not clear and has been an eyesore for me. I finally got around to making a change to it, and here it is.

#### Changes in this pull request *(Applied to all translations)*:
The option *"Disable Auto Tab Discarding Globally"*'s values:

* Before:  
  [***Off***, 1 hour, 6 hours, 12 hours, 1 day]

* After this pull request:  
  [***Never***, 1 hour, 6 hours, 12 hours, 1 day]


#### Postscript
In my opinion this is way clearer and I hope you accept this pull request.

---

For reference, here's the menu option in question:
> <img width="378" height="348" alt="image" src="https://github.com/user-attachments/assets/cb3226a5-e1dc-4dee-b53c-cb451eb3e108" />
