### PR TITLE
Add option to discard protected tabs when closing

### DIFF
--- a/v3/_locales/en/messages.json
+++ b/v3/_locales/en/messages.json
@@ -41,6 +41,9 @@
   "options_prepends": {
     "message": "Prepend a symbol to the discarded tabs (e.g. 💤 or ⏻︎) (if possible)"
   },
+  "options_discard_protected_on_close": {
+    "message": "Discard pinned or grouped tabs instead of closing them"
+  },
   "options_startup_unpinned": {
     "message": "Discard all unpinned tabs on a browser or extension startup"
   },

--- a/v3/data/options/index.html
+++ b/v3/data/options/index.html
@@ -59,6 +59,10 @@
           <td><input type="text" id="prepends"></td>
         </tr>
         <tr>
+          <td><input type="checkbox" id="discard-protected-on-close"></td>
+          <td colspan="2"><label for="discard-protected-on-close" data-i18n="options_discard_protected_on_close"></label></td>
+        </tr>
+        <tr>
           <td><input type="checkbox" id="startup-unpinned"></td>
           <td colspan="2"><label for="startup-unpinned" data-i18n="options_startup_unpinned"></label></td>
         </tr>

--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -56,6 +56,7 @@ const restore = () => storage({
   'faqs': true,
   'favicon': false,
   'prepends': '💤',
+  'discard-protected-on-close': false,
   'go-hidden': false,
   'memory-enabled': false,
   'memory-value': 60,
@@ -87,6 +88,7 @@ const restore = () => storage({
   document.getElementById('faqs').checked = prefs.faqs;
   document.getElementById('favicon').checked = prefs.favicon;
   document.getElementById('prepends').value = prefs.prepends;
+  document.getElementById('discard-protected-on-close').checked = prefs['discard-protected-on-close'];
   document.getElementById('go-hidden').checked = prefs['go-hidden'];
   if (prefs.period === 0) {
     document.getElementById('period').value = 0;
@@ -182,6 +184,7 @@ document.getElementById('save').addEventListener('click', () => {
     'faqs': document.getElementById('faqs').checked,
     'favicon': document.getElementById('favicon').checked,
     'prepends': document.getElementById('prepends').value,
+    'discard-protected-on-close': document.getElementById('discard-protected-on-close').checked,
     'go-hidden': document.getElementById('go-hidden').checked,
     'simultaneous-jobs': Math.max(1, Number(document.getElementById('simultaneous-jobs').value)),
     'favicon-delay': Math.max(100, Number(document.getElementById('favicon-delay').value)),

--- a/v3/schema.json
+++ b/v3/schema.json
@@ -73,6 +73,10 @@
       "title": "Change favicon of discarded tabs (if possible)",
       "type": "boolean"
     },
+    "discard-protected-on-close": {
+      "title": "Discard pinned or grouped tabs instead of closing them",
+      "type": "boolean"
+    },
     "go-hidden": {
       "title": "Discard a tab if it is hidden",
       "type": "boolean"

--- a/v3/worker/core/prefs.mjs
+++ b/v3/worker/core/prefs.mjs
@@ -1,6 +1,7 @@
 const prefs = {
   'favicon': false,
   'prepends': '💤',
+  'discard-protected-on-close': false,
   'number': 6,
   'period': 10 * 60, // in seconds
   'click': 'click.popup',

--- a/v3/worker/menu.mjs
+++ b/v3/worker/menu.mjs
@@ -323,7 +323,7 @@ import {interrupts} from './plugins/loader.mjs';
   }, tab));
   // commands
   chrome.commands.onCommand.addListener(async command => {
-    if (command.startsWith('move-') || command === 'close') {
+    if (command.startsWith('move-')) {
       navigate(command);
     }
     else {
@@ -332,9 +332,20 @@ import {interrupts} from './plugins/loader.mjs';
         currentWindow: true
       });
       if (tabs.length) {
+        const tab = tabs[0];
+        if (command === 'close') {
+          const settings = await storage({
+            'discard-protected-on-close': false
+          });
+          const grouped = Number.isInteger(tab.groupId) && tab.groupId !== -1;
+          if (settings['discard-protected-on-close'] === false || (!tab.pinned && !grouped)) {
+            navigate('close');
+            return;
+          }
+        }
         onClicked({
-          menuItemId: command
-        }, tabs[0]);
+          menuItemId: command === 'close' ? 'discard-tab' : command
+        }, tab);
       }
     }
   });


### PR DESCRIPTION
Closes #445.

## What changed

- Adds the `Discard pinned or grouped tabs instead of closing them` option.
- Routes the existing `Close Tab` command through the existing discard path when the option is enabled and the active tab is pinned or grouped.
- Preserves the existing close behavior when the option is disabled or the tab is ordinary.

The discard path retains the configured title symbol, favicon indicator, and plug-in hooks.

## Validation

- Ran JavaScript syntax and JSON validation for the modified MV3 files.
- Manually tested normal, pinned, and grouped tabs with the option enabled and disabled.

## Documentation follow-up

The option should include a `Read more` link once the hosted FAQ page can be updated. Proposed text:

> Browsers reserve their native close shortcut: Command+W on macOS and Ctrl+W on Windows and Linux. To use this option through that shortcut, map it with a system-level key remapper to Auto Tab Discard's Close Tab command. Karabiner-Elements is one macOS option; use an equivalent per-application remapper on other platforms.

## Localization

This adds the English source string. Other locales should be added through the existing translation workflow.
